### PR TITLE
Set Mac version to shutdown once window is shut

### DIFF
--- a/src/WebWindow.Native/WebWindow.Mac.AppDelegate.m
+++ b/src/WebWindow.Native/WebWindow.Mac.AppDelegate.m
@@ -13,6 +13,10 @@
     [NSApp activateIgnoringOtherApps:YES];
 }
 
+- (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
+    return true;
+}
+
 - (void)dealloc {
     [window release];
     [super dealloc];


### PR DESCRIPTION
This just tells the MacApp to shutdown automatically as soon as the window is shut, rather than needing to kill the app somehow