### PR TITLE
Added EventHandler for UriChanging

### DIFF
--- a/src/WebWindow.Native/Exports.cpp
+++ b/src/WebWindow.Native/Exports.cpp
@@ -134,4 +134,9 @@ extern "C"
 	{
 		instance->SetIconFile(filename);
 	}
+	
+	EXPORTED void WebWindow_SetUriChangeCallback(WebWindow* instance, UriChangeCallback callback)
+	{
+	    instance->SetUriChangeCallback(callback);
+	}
 }

--- a/src/WebWindow.Native/WebWindow.Linux.cpp
+++ b/src/WebWindow.Native/WebWindow.Linux.cpp
@@ -76,8 +76,7 @@ void HandleWebMessage(WebKitUserContentManager* contentManager, WebKitJavascript
 void HandleUriChange(GObject* object, WebKitLoadEvent event, gpointer user_data)
 {
     WebKitWebView *web_view;
-    
-    
+        
     const gchar *uri;
     
     if (event == WEBKIT_LOAD_FINISHED) {
@@ -87,7 +86,6 @@ void HandleUriChange(GObject* object, WebKitLoadEvent event, gpointer user_data)
         UriChangeCallback callback = (UriChangeCallback)user_data;
         callback(AutoString(uri));
     }
-    
 }
 
 void WebWindow::Show()
@@ -172,7 +170,6 @@ void WebWindow::ShowMessage(AutoString title, AutoString body, unsigned int type
 	gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_destroy(dialog);
 }
-
 
 void WebWindow::NavigateToUrl(AutoString url)
 {

--- a/src/WebWindow.Native/WebWindow.Linux.cpp
+++ b/src/WebWindow.Native/WebWindow.Linux.cpp
@@ -73,6 +73,23 @@ void HandleWebMessage(WebKitUserContentManager* contentManager, WebKitJavascript
 	webkit_javascript_result_unref(jsResult);
 }
 
+void HandleUriChange(GObject* object, WebKitLoadEvent event, gpointer user_data)
+{
+    WebKitWebView *web_view;
+    
+    
+    const gchar *uri;
+    
+    if (event == WEBKIT_LOAD_FINISHED) {
+        web_view = WEBKIT_WEB_VIEW(object);
+        uri = webkit_web_view_get_uri(web_view);
+        
+        UriChangeCallback callback = (UriChangeCallback)user_data;
+        callback(AutoString(uri));
+    }
+    
+}
+
 void WebWindow::Show()
 {
 	if (!_webview)
@@ -99,6 +116,7 @@ void WebWindow::Show()
 
 		g_signal_connect(contentManager, "script-message-received::webwindowinterop",
 			G_CALLBACK(HandleWebMessage), (void*)_webMessageReceivedCallback);
+		g_signal_connect(_webview, "load-changed", G_CALLBACK(HandleUriChange), (void*)_uriChangeCallback);
 		webkit_user_content_manager_register_script_message_handler(contentManager, "webwindowinterop");
 	}
 
@@ -154,6 +172,7 @@ void WebWindow::ShowMessage(AutoString title, AutoString body, unsigned int type
 	gtk_dialog_run(GTK_DIALOG(dialog));
 	gtk_widget_destroy(dialog);
 }
+
 
 void WebWindow::NavigateToUrl(AutoString url)
 {

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.h
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.h
@@ -1,0 +1,13 @@
+#import <Cocoa/Cocoa.h>
+#import <WebKit/WebKit.h>
+#include "WebWindow.h"
+
+typedef void (*UriChangedCallback) (char* message);
+
+@interface MyNavigationDelegate : NSObject <WKNavigationDelegate> {
+    @public
+    NSWindow * window;
+    WebWindow * webWindow;
+    UriChangedCallback uriChangedCallback;
+}
+@end

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -18,7 +18,7 @@ didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
     callUriChangedCallback(webView.URL.absoluteString);
 }
 
-- (void) callUriChangedCallback: (NSString) uri;
+- (void) callUriChangedCallback: (NSString *) uri;
 {
     int length = strlen(uri);
     char* uriWritable = new char[ length + 1]();

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -4,29 +4,26 @@
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation;
 {
-    const char* uri = [webView.URL.absoluteString UTF8String];
-    int length = strlen(uri);
-    char* uriWritable = new char[length + 1]();
-    strncpy(uriWritable, uri, length);
-    uriChangedCallback(uriWritable);
+    callUriChangedCallback(webView);
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error;
 {
-const char* uri = [webView.URL.absoluteString UTF8String];
-int length = strlen(uri);
-char* uriWritable = new char[ length + 1]();
-strncpy(uriWritable, uri, length);
-uriChangedCallback(uriWritable);
+    callUriChangedCallback(webView);
 }
 
 - (void)webView:(WKWebView *)webView
 didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
 {
-const char* uri = [webView.URL.absoluteString UTF8String];
-int length = strlen(uri);
-char* uriWritable = new char[ length + 1]();
-strncpy(uriWritable, uri, length);
-uriChangedCallback(uriWritable);
+    callUriChangedCallback(webView);
+}
+
+void callURIChangedCallback(WKWebView *webView)
+{
+    const char* uri = [webView.URL.absoluteString UTF8String];
+    int length = strlen(uri);
+    char* uriWritable = new char[ length + 1]();
+    strncpy(uriWritable, uri, length);
+    uriChangedCallback(uriWritable);
 }
 @end

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -4,25 +4,25 @@
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
 }
 
 - (void)webView:(WKWebView *)webView
 didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
 }
 
-void callUriChangedCallback(const char* uri, UriChangedCallback* callback)
+void MyNavigationDelegate::callUriChangedCallback(const char* uri)
 {
     int length = strlen(uri);
     char* uriWritable = new char[ length + 1]();
     strncpy(uriWritable, uri, length);
-    callback(uriWritable);
+    uriChangedCallback(uriWritable);
 }
 @end

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -18,7 +18,7 @@ didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
     callUriChangedCallback([webView.URL.absoluteString UTF8String]);
 }
 
-void MyNavigationDelegate::callUriChangedCallback(const char* uri)
+- (void) callUriChangedCallback: (const char*) uri;
 {
     int length = strlen(uri);
     char* uriWritable = new char[ length + 1]();

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -18,7 +18,7 @@ didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
     callUriChangedCallback(webView);
 }
 
-void callURIChangedCallback(WKWebView *webView)
+void callUriChangedCallback(WKWebView *webView)
 {
     const char* uri = [webView.URL.absoluteString UTF8String];
     int length = strlen(uri);

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -4,21 +4,21 @@
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
+    callUriChangedCallback(webView.URL.absoluteString);
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
+    callUriChangedCallback(webView.URL.absoluteString);
 }
 
 - (void)webView:(WKWebView *)webView
 didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback([webView.URL.absoluteString UTF8String]);
+    callUriChangedCallback(webView.URL.absoluteString);
 }
 
-- (void) callUriChangedCallback: (const char*) uri;
+- (void) callUriChangedCallback: (NSString) uri;
 {
     int length = strlen(uri);
     char* uriWritable = new char[ length + 1]();

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -1,0 +1,32 @@
+#import "WebWindow.Mac.NavigationDelegate.h"
+
+@implementation MyNavigationDelegate : NSObject
+
+- (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation;
+{
+    const char* uri = [webView.URL.absoluteString UTF8String];
+    int length = strlen(uri);
+    char* uriWritable = new char[ length + 1]();
+    strncpy(uriWritable, uri, length);
+    uriChangedCallback(uriWritable);
+}
+
+- (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error;
+{
+const char* uri = [webView.URL.absoluteString UTF8String];
+int length = strlen(uri);
+char* uriWritable = new char[ length + 1]();
+strncpy(uriWritable, uri, length);
+uriChangedCallback(uriWritable);
+}
+
+- (void)webView:(WKWebView *)webView
+didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
+{
+const char* uri = [webView.URL.absoluteString UTF8String];
+int length = strlen(uri);
+char* uriWritable = new char[ length + 1]();
+strncpy(uriWritable, uri, length);
+uriChangedCallback(uriWritable);
+}
+@end

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -4,26 +4,25 @@
 
 - (void)webView:(WKWebView *)webView didStartProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback(webView);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
 }
 
 - (void)webView:(WKWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error;
 {
-    callUriChangedCallback(webView);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
 }
 
 - (void)webView:(WKWebView *)webView
 didReceiveServerRedirectForProvisionalNavigation:(WKNavigation *)navigation;
 {
-    callUriChangedCallback(webView);
+    callUriChangedCallback([webView.URL.absoluteString UTF8String], uriChangedCallback);
 }
 
-void callUriChangedCallback(WKWebView *webView)
+void callUriChangedCallback(const char* uri, UriChangedCallback* callback)
 {
-    const char* uri = [webView.URL.absoluteString UTF8String];
     int length = strlen(uri);
     char* uriWritable = new char[ length + 1]();
     strncpy(uriWritable, uri, length);
-    uriChangedCallback(uriWritable);
+    callback(uriWritable);
 }
 @end

--- a/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.NavigationDelegate.mm
@@ -6,7 +6,7 @@
 {
     const char* uri = [webView.URL.absoluteString UTF8String];
     int length = strlen(uri);
-    char* uriWritable = new char[ length + 1]();
+    char* uriWritable = new char[length + 1]();
     strncpy(uriWritable, uri, length);
     uriChangedCallback(uriWritable);
 }

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -96,7 +96,6 @@ void WebWindow::AttachWebView()
     [webView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [window.contentView addSubview:webView];
     [window.contentView setAutoresizesSubviews:YES];
-    
     uiDelegate->window = window;
     webView.UIDelegate = uiDelegate;
     uiDelegate->webMessageReceivedCallback = _webMessageReceivedCallback;

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -72,7 +72,6 @@ void WebWindow::AttachWebView()
 
     MyNavigationDelegate *navDelegate = [[[MyNavigationDelegate alloc] init] autorelease];
     
-
     NSString *initScriptSource = @"window.__receiveMessageCallbacks = [];"
 			"window.__dispatchMessageCallback = function(message) {"
 			"	window.__receiveMessageCallbacks.forEach(function(callback) { callback(message); });"

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -3,6 +3,7 @@
 #import "WebWindow.Mac.AppDelegate.h"
 #import "WebWindow.Mac.UiDelegate.h"
 #import "WebWindow.Mac.UrlSchemeHandler.h"
+#import "WebWindow.Mac.NavigationDelegate.h"
 #include <cstdio>
 #include <map>
 #import <Cocoa/Cocoa.h>
@@ -69,6 +70,9 @@ void WebWindow::AttachWebView()
     MyUiDelegate *uiDelegate = [[[MyUiDelegate alloc] init] autorelease];
     uiDelegate->webWindow = this;
 
+    MyNavigationDelegate *navDelegate = [[[MyNavigationDelegate alloc] init] autorelease];
+    
+
     NSString *initScriptSource = @"window.__receiveMessageCallbacks = [];"
 			"window.__dispatchMessageCallback = function(message) {"
 			"	window.__receiveMessageCallbacks.forEach(function(callback) { callback(message); });"
@@ -92,12 +96,18 @@ void WebWindow::AttachWebView()
     [webView setAutoresizingMask:NSViewWidthSizable | NSViewHeightSizable];
     [window.contentView addSubview:webView];
     [window.contentView setAutoresizesSubviews:YES];
-
+    
     uiDelegate->window = window;
     webView.UIDelegate = uiDelegate;
-
+    
     uiDelegate->webMessageReceivedCallback = _webMessageReceivedCallback;
     [userContentController addScriptMessageHandler:uiDelegate name:@"webwindowinterop"];
+
+    navDelegate->window = window;
+    navDelegate->webWindow = this;
+    navDelegate->uriChangedCallback = _uriChangeCallback;
+
+    webView.navigationDelegate = navDelegate;
 
     // TODO: Remove these observers when the window is closed
     [[NSNotificationCenter defaultCenter] addObserver:uiDelegate selector:@selector(windowDidResize:) name:NSWindowDidResizeNotification object:window];

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -99,7 +99,6 @@ void WebWindow::AttachWebView()
     
     uiDelegate->window = window;
     webView.UIDelegate = uiDelegate;
-    
     uiDelegate->webMessageReceivedCallback = _webMessageReceivedCallback;
     [userContentController addScriptMessageHandler:uiDelegate name:@"webwindowinterop"];
 

--- a/src/WebWindow.Native/WebWindow.Native.vcxproj
+++ b/src/WebWindow.Native/WebWindow.Native.vcxproj
@@ -153,9 +153,13 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="WebWindow.h" />
+    <ClInclude Include="WebWindow.Mac.NavigationDelegate.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="WebWindow.Mac.NavigationDelegate.mm" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/WebWindow.Native/WebWindow.Windows.cpp
+++ b/src/WebWindow.Native/WebWindow.Windows.cpp
@@ -228,15 +228,16 @@ void WebWindow::AttachWebView()
                         // Add a navigation change event handler
 						EventRegistrationToken token;
                         _webviewWindow->add_NavigationStarting(Callback<IWebView2NavigationStartingEventHandler>(
-                            [this](IWebView2WebView* webview, IWebView2NavigationStartingEventArgs * args) -> HRESULT {
+                            [this](IWebView2WebView* webview, IWebView2NavigationStartingEventArgs * args) -> HRESULT 
+                            {
                                 PWSTR uri;
                                 args->get_Uri(&uri);
                                 _uriChangeCallback(uri);
                                 CoTaskMemFree(uri);
                                 return S_OK;
-                            }).Get(), &token);
-                        
-                        
+                            }
+                        ).Get(), &token);
+                                                
 						// Register interop APIs
 						EventRegistrationToken webMessageToken;
 						_webviewWindow->AddScriptToExecuteOnDocumentCreated(L"window.external = { sendMessage: function(message) { window.chrome.webview.postMessage(message); }, receiveMessage: function(callback) { window.chrome.webview.addEventListener(\'message\', function(e) { callback(e.data); }); } };", nullptr);

--- a/src/WebWindow.Native/WebWindow.Windows.cpp
+++ b/src/WebWindow.Native/WebWindow.Windows.cpp
@@ -225,7 +225,18 @@ void WebWindow::AttachWebView()
 						Settings->put_IsScriptEnabled(TRUE);
 						Settings->put_AreDefaultScriptDialogsEnabled(TRUE);
 						Settings->put_IsWebMessageEnabled(TRUE);
-
+                        // Add a navigation change event handler
+						EventRegistrationToken token;
+                        _webviewWindow->add_NavigationStarting(Callback<IWebView2NavigationStartingEventHandler>(
+                            [this](IWebView2WebView* webview, IWebView2NavigationStartingEventArgs * args) -> HRESULT {
+                                PWSTR uri;
+                                args->get_Uri(&uri);
+                                _uriChangeCallback(uri);
+                                CoTaskMemFree(uri);
+                                return S_OK;
+                            }).Get(), &token);
+                        
+                        
 						// Register interop APIs
 						EventRegistrationToken webMessageToken;
 						_webviewWindow->AddScriptToExecuteOnDocumentCreated(L"window.external = { sendMessage: function(message) { window.chrome.webview.postMessage(message); }, receiveMessage: function(callback) { window.chrome.webview.addEventListener(\'message\', function(e) { callback(e.data); }); } };", nullptr);

--- a/src/WebWindow.Native/WebWindow.h
+++ b/src/WebWindow.Native/WebWindow.h
@@ -31,6 +31,7 @@ typedef void* (*WebResourceRequestedCallback)(AutoString url, int* outNumBytes, 
 typedef int (*GetAllMonitorsCallback)(const Monitor* monitor);
 typedef void (*ResizedCallback)(int width, int height);
 typedef void (*MovedCallback)(int x, int y);
+typedef void (*UriChangeCallback)(AutoString url);
 
 class WebWindow
 {
@@ -38,6 +39,7 @@ private:
 	WebMessageReceivedCallback _webMessageReceivedCallback;
 	MovedCallback _movedCallback;
 	ResizedCallback _resizedCallback;
+	UriChangeCallback _uriChangeCallback;
 #ifdef _WIN32
 	static HINSTANCE _hInstance;
 	HWND _hWnd;
@@ -87,6 +89,8 @@ public:
 	void SetPosition(int x, int y);
 	void SetMovedCallback(MovedCallback callback) { _movedCallback = callback; }
 	void InvokeMoved(int x, int y) { if (_movedCallback) _movedCallback(x, y); }
+	void SetUriChangeCallback(UriChangeCallback callback) { _uriChangeCallback = callback; }
+	void InvokeUriChange(AutoString uri) { if (_uriChangeCallback) _uriChangeCallback(uri); }
 	void SetTopmost(bool topmost);
 	void SetIconFile(AutoString filename);
 };

--- a/src/WebWindow/WebWindow.cs
+++ b/src/WebWindow/WebWindow.cs
@@ -55,10 +55,7 @@ namespace WebWindows
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)] delegate int GetAllMonitorsCallback(in NativeMonitor monitor);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)] delegate void ResizedCallback(int width, int height);
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)] delegate void MovedCallback(int x, int y);
-
-        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        delegate void UriChangeCallback(string uri); 
-
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl, CharSet = CharSet.Auto)] delegate void UriChangeCallback(string uri); 
         const string DllName = "WebWindow.Native";
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern IntPtr WebWindow_register_win32(IntPtr hInstance);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern IntPtr WebWindow_register_mac();
@@ -85,9 +82,7 @@ namespace WebWindows
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern void WebWindow_SetMovedCallback(IntPtr instance, MovedCallback callback);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern void WebWindow_SetTopmost(IntPtr instance, int topmost);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)] static extern void WebWindow_SetIconFile(IntPtr instance, string filename);
-
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)]
-        static extern void WebWindow_SetUriChangeCallback(IntPtr instance, UriChangeCallback callback);
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)] static extern void WebWindow_SetUriChangeCallback(IntPtr instance, UriChangeCallback callback);
 
         private readonly List<GCHandle> _gcHandlesToFree = new List<GCHandle>();
         private readonly List<IntPtr> _hGlobalToFree = new List<IntPtr>();

--- a/src/WebWindow/WebWindow.csproj
+++ b/src/WebWindow/WebWindow.csproj
@@ -20,7 +20,7 @@
     <MakeDir Directories="..\WebWindow.Native\x64\$(Configuration)" />
     <Exec Condition="'$(IsMacOS)' == 'true'"
           WorkingDirectory="..\WebWindow.Native"
-          Command="gcc -shared -lstdc++ -DOS_MAC -framework Cocoa -framework WebKit WebWindow.Mac.mm Exports.cpp WebWindow.Mac.AppDelegate.mm WebWindow.Mac.UiDelegate.mm WebWindow.Mac.UrlSchemeHandler.m -o x64/$(Configuration)/WebWindow.Native.dylib" />
+          Command="gcc -shared -lstdc++ -DOS_MAC -framework Cocoa -framework WebKit WebWindow.Mac.mm Exports.cpp WebWindow.Mac.AppDelegate.mm WebWindow.Mac.UiDelegate.mm WebWindow.Mac.UrlSchemeHandler.m WebWindow.Mac.NavigationDelegate.mm -o x64/$(Configuration)/WebWindow.Native.dylib" />
     <Exec Condition="'$(IsMacOS)' != 'true'"
           WorkingDirectory="..\WebWindow.Native"
           Command="gcc -std=c++11 -shared -DOS_LINUX Exports.cpp WebWindow.Linux.cpp -o x64/$(Configuration)/WebWindow.Native.so `pkg-config --cflags --libs gtk+-3.0 webkit2gtk-4.0` -fPIC" />

--- a/src/WebWindow/WebWindowOptions.cs
+++ b/src/WebWindow/WebWindowOptions.cs
@@ -9,7 +9,6 @@ namespace WebWindows
 
         public IDictionary<string, ResolveWebResourceDelegate> SchemeHandlers { get; }
             = new Dictionary<string, ResolveWebResourceDelegate>();
-        
     }
 
     public delegate Stream ResolveWebResourceDelegate(string url, out string contentType);

--- a/src/WebWindow/WebWindowOptions.cs
+++ b/src/WebWindow/WebWindowOptions.cs
@@ -9,6 +9,7 @@ namespace WebWindows
 
         public IDictionary<string, ResolveWebResourceDelegate> SchemeHandlers { get; }
             = new Dictionary<string, ResolveWebResourceDelegate>();
+        
     }
 
     public delegate Stream ResolveWebResourceDelegate(string url, out string contentType);

--- a/testassets/HelloWorldApp/Program.cs
+++ b/testassets/HelloWorldApp/Program.cs
@@ -22,7 +22,10 @@ namespace HelloWorldApp
             {
                 window.SendMessage("Got message: " + message);
             };
-
+            window.OnUriChange += (sender, uri) =>
+            {
+                Console.WriteLine($"New URI: {uri}");
+            };
             window.NavigateToLocalFile("wwwroot/index.html");
             window.WaitForExit();
         }

--- a/testassets/HelloWorldApp/wwwroot/index.html
+++ b/testassets/HelloWorldApp/wwwroot/index.html
@@ -9,7 +9,7 @@
     </p>
     
     <p>
-        <a href="http://www.microsoft.com">Link to Microsoft</a>
+        <a href="http://www.example.com">Link to example.com</a>
     </p>
 
     <script src="app://something.js"></script>

--- a/testassets/HelloWorldApp/wwwroot/index.html
+++ b/testassets/HelloWorldApp/wwwroot/index.html
@@ -7,6 +7,10 @@
     <p>
         <button onclick="callDotNet()">Call .NET</button>
     </p>
+    
+    <p>
+        <a href="http://www.microsoft.com">Link to Microsoft</a>
+    </p>
 
     <script src="app://something.js"></script>
 


### PR DESCRIPTION
Added functionality to add an event handler for URI Changes.

This allows for usage of WebWindow in an OAuth context to capture the redirect URI for the Authorization Code flow.

Added functionality and tested for Windows (Win10), Linux (Ubuntu 19.10) and OSX (10.14 Mojave)