### PR TITLE
Added .wasm file MIME type to ComponentDesktop.GetContentType

### DIFF
--- a/src/WebWindow.Blazor/ComponentsDesktop.cs
+++ b/src/WebWindow.Blazor/ComponentsDesktop.cs
@@ -90,6 +90,7 @@ namespace WebWindows.Blazor
                 case ".html": return "text/html";
                 case ".css": return "text/css";
                 case ".js": return "text/javascript";
+                case ".wasm": return "application/wasm";
             }
             return "application/octet-stream";
         }


### PR DESCRIPTION
Added switch case for the WebAssembly file (.wasm) MIME type "application/wasm" to ComponentDesktop.GetContentType