### PR TITLE
Add PackageId and RepositoryUrl to csproj

### DIFF
--- a/src/WebWindow/WebWindow.csproj
+++ b/src/WebWindow/WebWindow.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <Title>WebWindow</Title>
+    <PackageId>WebWindow</PackageId>
     <PackageDescription>Open native OS windows hosting web UI on Windows, Mac, and Linux</PackageDescription>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <RepositoryUrl>https://github.com/SteveSandersonMS/WebWindow</RepositoryUrl>
     <TargetFramework>netstandard2.1</TargetFramework>
     <NativeOutputDir>..\WebWindow.Native\x64\$(Configuration)\</NativeOutputDir>
     <IsMacOS>$([MSBuild]::IsOsPlatform('OSX'))</IsMacOS>


### PR DESCRIPTION
This should enable the GitHub dependant page/button (#62)

Thanks @IvanJosipovic for the suggestion:
https://github.com/SteveSandersonMS/WebWindow/issues/62#issuecomment-587213678