### PR TITLE
fullscreen, size and position

### DIFF
--- a/src/WebWindow.Blazor/ComponentsDesktop.cs
+++ b/src/WebWindow.Blazor/ComponentsDesktop.cs
@@ -23,7 +23,7 @@ namespace WebWindows.Blazor
         internal static DesktopRenderer DesktopRenderer { get; private set; }
         internal static WebWindow WebWindow { get; private set; }
 
-        public static void Run<TStartup>(string windowTitle, string hostHtmlPath)
+        public static void Run<TStartup>(string windowTitle, string hostHtmlPath, bool fullscreen = false, int x = 0, int y = 0, int width = 800, int height = 600)
         {
             DesktopSynchronizationContext.UnhandledException += (sender, exception) =>
             {
@@ -54,7 +54,7 @@ namespace WebWindows.Blazor
                     contentType = GetContentType(url);
                     return SupplyFrameworkFile(url);
                 });
-            });
+            }, fullscreen, x, y, width, height);
 
             CancellationTokenSource appLifetimeCts = new CancellationTokenSource();
             Task.Factory.StartNew(async () =>

--- a/src/WebWindow.Native/Exports.cpp
+++ b/src/WebWindow.Native/Exports.cpp
@@ -25,9 +25,9 @@ extern "C"
 	}
 #endif
 
-	EXPORTED WebWindow* WebWindow_ctor(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback)
+	EXPORTED WebWindow* WebWindow_ctor(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height)
 	{
-		return new WebWindow(title, parent, webMessageReceivedCallback);
+		return new WebWindow(title, parent, webMessageReceivedCallback, fullscreen, x, y, width, height);
 	}
 
 	EXPORTED void WebWindow_dtor(WebWindow* instance)

--- a/src/WebWindow.Native/WebWindow.Linux.cpp
+++ b/src/WebWindow.Native/WebWindow.Linux.cpp
@@ -27,7 +27,7 @@ struct InvokeJSWaitInfo
 void on_size_allocate(GtkWidget* widget, GdkRectangle* allocation, gpointer self);
 gboolean on_configure_event(GtkWidget* widget, GdkEvent* event, gpointer self);
 
-WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback) : _webview(nullptr)
+WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height) : _webview(nullptr)
 {
 	_webMessageReceivedCallback = webMessageReceivedCallback;
 
@@ -37,7 +37,22 @@ WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCall
 
 	gtk_init(0, NULL);
 	_window = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-	gtk_window_set_default_size(GTK_WINDOW(_window), 900, 600);
+
+	if (fullscreen)
+	{
+		GdkRectangle geometry = { 0 };
+		gdk_monitor_get_geometry(gdk_display_get_primary_monitor(gdk_display_get_default()), &geometry);
+
+		x = 0;
+		y = 0;
+		width = geometry.width;
+		height = geometry.height;
+
+		gtk_window_fullscreen(GTK_WINDOW(_window));
+	}
+
+	gtk_window_move(GTK_WINDOW(_window), x, y);
+	gtk_window_set_default_size(GTK_WINDOW(_window), width, height);
 	SetTitle(title);
 
 	if (parent == NULL)

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -34,10 +34,10 @@ void WebWindow::Register()
     [application setDelegate:appDelegate];
 }
 
-WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback)
+WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height)
 {
     _webMessageReceivedCallback = webMessageReceivedCallback;
-    NSRect frame = NSMakeRect(0, 0, 900, 600);
+    NSRect frame = NSMakeRect(x, y, width, height);
     NSWindow *window = [[NSWindow alloc]
         initWithContentRect:frame
         styleMask:NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | NSWindowStyleMaskResizable | NSWindowStyleMaskMiniaturizable

--- a/src/WebWindow.Native/WebWindow.Windows.cpp
+++ b/src/WebWindow.Native/WebWindow.Windows.cpp
@@ -46,19 +46,28 @@ void WebWindow::Register(HINSTANCE hInstance)
 	SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE);
 }
 
-WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback)
+WebWindow::WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x = CW_USEDEFAULT, int y = CW_USEDEFAULT, int width = CW_USEDEFAULT, int height = CW_USEDEFAULT)
 {
 	// Create the window
 	_webMessageReceivedCallback = webMessageReceivedCallback;
 	_parent = parent;
+
+	if (fullscreen)
+	{
+		x = 0;
+		y = 0;
+		width = GetSystemMetrics(SM_CXSCREEN);
+		height = GetSystemMetrics(SM_CYSCREEN);
+	}
+
 	_hWnd = CreateWindowEx(
 		0,                              // Optional window styles.
 		CLASS_NAME,                     // Window class
 		title,							// Window text
-		WS_OVERLAPPEDWINDOW,            // Window style
+		fullscreen ? WS_POPUP : WS_OVERLAPPEDWINDOW,	// Window style
 
 		// Size and position
-		CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
+		x, y, width, height,
 
 		parent ? parent->_hWnd : NULL,       // Parent window
 		NULL,       // Menu

--- a/src/WebWindow.Native/WebWindow.h
+++ b/src/WebWindow.Native/WebWindow.h
@@ -65,7 +65,7 @@ public:
 	static void Register();
 #endif
 
-	WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback);
+	WebWindow(AutoString title, WebWindow* parent, WebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height);
 	~WebWindow();
 	void SetTitle(AutoString title);
 	void Show();

--- a/src/WebWindow/WebWindow.cs
+++ b/src/WebWindow/WebWindow.cs
@@ -59,7 +59,7 @@ namespace WebWindows
         const string DllName = "WebWindow.Native";
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern IntPtr WebWindow_register_win32(IntPtr hInstance);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern IntPtr WebWindow_register_mac();
-        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)] static extern IntPtr WebWindow_ctor(string title, IntPtr parentWebWindow, OnWebMessageReceivedCallback webMessageReceivedCallback);
+        [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)] static extern IntPtr WebWindow_ctor(string title, IntPtr parentWebWindow, OnWebMessageReceivedCallback webMessageReceivedCallback, bool fullscreen, int x, int y, int width, int height);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern void WebWindow_dtor(IntPtr instance);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)] static extern IntPtr WebWindow_getHwnd_win32(IntPtr instance);
         [DllImport(DllName, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Auto)] static extern void WebWindow_SetTitle(IntPtr instance, string title);
@@ -112,7 +112,7 @@ namespace WebWindows
         {
         }
 
-        public WebWindow(string title, Action<WebWindowOptions> configure)
+        public WebWindow(string title, Action<WebWindowOptions> configure, bool fullscreen = false, int x = 0, int y = 0, int width = 800, int height = 600)
         {
             _ownerThreadId = Thread.CurrentThread.ManagedThreadId;
 
@@ -130,7 +130,7 @@ namespace WebWindows
             _gcHandlesToFree.Add(GCHandle.Alloc(onWebMessageReceivedDelegate));
 
             var parentPtr = options.Parent?._nativeWebWindow ?? default;
-            _nativeWebWindow = WebWindow_ctor(_title, parentPtr, onWebMessageReceivedDelegate);
+            _nativeWebWindow = WebWindow_ctor(_title, parentPtr, onWebMessageReceivedDelegate, fullscreen, x, y, width, height);
 
             foreach (var (schemeName, handler) in options.SchemeHandlers)
             {


### PR DESCRIPTION
While it is possible to set window size and position from C# like this:

        public void Configure(DesktopApplicationBuilder app)
        {
            app.AddComponent<App>("app");

            WebWindow webWindow = app.Services.GetService<WebWindow>();

            webWindow.Top = 0;
            webWindow.Left = 0;
            webWindow.Width = 800;
            webWindow.Height = 600;
        }

The problem is that it takes from 1 to 2 seconds for this settings to take effect.

That is why I added:

bool fullscreen
int x, int y
int width, int height

to all C++ and C# functions