### PR TITLE
Add svg file support to Blazor

### DIFF
--- a/src/WebWindow.Blazor/ComponentsDesktop.cs
+++ b/src/WebWindow.Blazor/ComponentsDesktop.cs
@@ -91,6 +91,7 @@ namespace WebWindows.Blazor
                 case ".css": return "text/css";
                 case ".js": return "text/javascript";
                 case ".wasm": return "application/wasm";
+                case ".svg": return "image/svg+xml";
             }
             return "application/octet-stream";
         }


### PR DESCRIPTION
This allows a svg file to be displayed inside an img tag.  For example:
<img src="a_svg_file.svg"/>