### PR TITLE
Bugfix. argsArray[1] can be null for DotNetReferences.

### DIFF
--- a/src/WebWindow.Blazor/ComponentsDesktop.cs
+++ b/src/WebWindow.Blazor/ComponentsDesktop.cs
@@ -192,7 +192,7 @@ namespace WebWindows.Blazor
                     DotNetDispatcher.BeginInvokeDotNet(
                         DesktopJSRuntime,
                         new DotNetInvocationInfo(
-                            assemblyName: ((JsonElement)argsArray[1]).GetString(),
+                            assemblyName: argsArray[1] != null ? ((JsonElement)argsArray[1]).GetString() : null,
                             methodIdentifier: ((JsonElement)argsArray[2]).GetString(),
                             dotNetObjectId: ((JsonElement)argsArray[3]).GetInt64(),
                             callId: ((JsonElement)argsArray[0]).GetString()),


### PR DESCRIPTION
 argsArray[1] can be null for DotNetReferences.