### PR TITLE
Added EnsureInvoke, Show Message no longer crashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.DS_Store
 .vs/
 .vscode/
 bin/

--- a/src/WebWindow.Native/WebWindow.Mac.mm
+++ b/src/WebWindow.Native/WebWindow.Mac.mm
@@ -134,15 +134,29 @@ void WebWindow::Invoke(ACTION callback)
         callback();
     });
 }
+void EnsureInvoke(dispatch_block_t block)
+{
+    if ([NSThread isMainThread])
+    {
+        block();
+    }
+    else
+    {
+        dispatch_async(dispatch_get_main_queue(), block);
+    }
+}
 
 void WebWindow::ShowMessage(AutoString title, AutoString body, unsigned int type)
 {
-    NSString* nstitle = [[NSString stringWithUTF8String:title] autorelease];
-    NSString* nsbody= [[NSString stringWithUTF8String:body] autorelease];
-    NSAlert *alert = [[[NSAlert alloc] init] autorelease];
-    [[alert window] setTitle:nstitle];
-    [alert setMessageText:nsbody];
-    [alert runModal];
+
+    EnsureInvoke(^{
+        NSString* nstitle = [[NSString stringWithUTF8String:title] autorelease];
+        NSString* nsbody= [[NSString stringWithUTF8String:body] autorelease];
+        NSAlert *alert = [[[NSAlert alloc] init] autorelease];
+        [[alert window] setTitle:nstitle];
+        [alert setMessageText:nsbody];
+        [alert runModal];
+    });
 }
 
 void WebWindow::NavigateToString(AutoString content)


### PR DESCRIPTION
Messages come from a background thread, so we need to ensure that we invoke the alert on the main thread. Without this the app crashes.