### PR TITLE
Make ComponentsDesktop.WebWindow public

### DIFF
--- a/src/WebWindow.Blazor/ComponentsDesktop.cs
+++ b/src/WebWindow.Blazor/ComponentsDesktop.cs
@@ -21,7 +21,7 @@ namespace WebWindows.Blazor
         internal static string BaseUriAbsolute { get; private set; }
         internal static DesktopJSRuntime DesktopJSRuntime { get; private set; }
         internal static DesktopRenderer DesktopRenderer { get; private set; }
-        internal static WebWindow WebWindow { get; private set; }
+        public static WebWindow WebWindow { get; private set; }
 
         public static void Run<TStartup>(string windowTitle, string hostHtmlPath)
         {


### PR DESCRIPTION
Currently, there appears to be no way to access the `WebWindow` instance running from `ComponentsDesktop`. This change allows for that.

Addresses #118.